### PR TITLE
fix(wdio-browserstack-service): close O11y build on all termination paths [SDK-5981]

### DIFF
--- a/packages/wdio-browserstack-service/src/exitHandler.ts
+++ b/packages/wdio-browserstack-service/src/exitHandler.ts
@@ -12,47 +12,109 @@ import { BrowserstackCLI } from './cli/index.js'
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 
-export function setupExitHandlers() {
-    const handleCLICleanup = () => {
-        BStackLogger.debug('Handling CLI cleanup in exit handler')
-        try {
-            const cliProcess = BrowserstackCLI.getInstance()?.process
+// Module-level guard so cleanup runs at most once, regardless of how many
+// termination paths fire (exit / signals / errors can overlap). SDK-5981.
+let cleanupHasRun = false
 
-            if (cliProcess && cliProcess.pid && cliProcess.exitCode === null) {
-                BStackLogger.debug(`Found CLI process with PID ${cliProcess.pid}, terminating`)
-                try {
-                    if (process.platform === 'win32') {
-                        cliProcess.kill('SIGTERM')
-                        BStackLogger.debug('CLI process terminated successfully with SIGTERM (Windows)')
-                    } else {
-                        cliProcess.kill('SIGINT')
-                        BStackLogger.debug('CLI process terminated successfully with SIGINT (Unix)')
-                    }
-                } catch (processError) {
-                    BStackLogger.debug(`CLI process termination error: ${processError}`)
-                    try {
-                        cliProcess.kill()
-                        BStackLogger.debug('CLI process terminated with default signal (fallback)')
-                    } catch (fallbackError) {
-                        BStackLogger.debug(`CLI process fallback termination error: ${fallbackError}`)
-                    }
-                }
-            } else {
-                BStackLogger.debug('No CLI process found to terminate')
-            }
-        } catch (error) {
-            BStackLogger.debug(`Error in CLI cleanup: ${error}`)
-        }
+function runExitCleanup() {
+    if (cleanupHasRun) {
+        return
     }
-    process.on('exit', () => {
-        const isCLIEnabled = BrowserstackCLI.getInstance().isRunning()
-        handleCLICleanup()
-        const args = shouldCallCleanup(BrowserStackConfig.getInstance(), isCLIEnabled)
-        if (Array.isArray(args) && args.length) {
-            BStackLogger.debug(`Spawning cleanup.js with args: ${args.join(', ')}`)
-            const childProcess = spawn('node', [`${path.join(__dirname, 'cleanup.js')}`, ...args], { detached: true, stdio: 'inherit', env: { ...process.env } })
-            childProcess.unref()
+    cleanupHasRun = true
+
+    const isCLIEnabled = BrowserstackCLI.getInstance().isRunning()
+    handleCLICleanup()
+    const args = shouldCallCleanup(BrowserStackConfig.getInstance(), isCLIEnabled)
+    if (Array.isArray(args) && args.length) {
+        BStackLogger.debug(`Spawning cleanup.js with args: ${args.join(', ')}`)
+        const childProcess = spawn('node', [`${path.join(__dirname, 'cleanup.js')}`, ...args], { detached: true, stdio: 'inherit', env: { ...process.env } })
+        childProcess.unref()
+    }
+}
+
+function handleCLICleanup() {
+    BStackLogger.debug('Handling CLI cleanup in exit handler')
+    try {
+        const cliProcess = BrowserstackCLI.getInstance()?.process
+
+        if (cliProcess && cliProcess.pid && cliProcess.exitCode === null) {
+            BStackLogger.debug(`Found CLI process with PID ${cliProcess.pid}, terminating`)
+            try {
+                if (process.platform === 'win32') {
+                    cliProcess.kill('SIGTERM')
+                    BStackLogger.debug('CLI process terminated successfully with SIGTERM (Windows)')
+                } else {
+                    cliProcess.kill('SIGINT')
+                    BStackLogger.debug('CLI process terminated successfully with SIGINT (Unix)')
+                }
+            } catch (processError) {
+                BStackLogger.debug(`CLI process termination error: ${processError}`)
+                try {
+                    cliProcess.kill()
+                    BStackLogger.debug('CLI process terminated with default signal (fallback)')
+                } catch (fallbackError) {
+                    BStackLogger.debug(`CLI process fallback termination error: ${fallbackError}`)
+                }
+            }
+        } else {
+            BStackLogger.debug('No CLI process found to terminate')
         }
+    } catch (error) {
+        BStackLogger.debug(`Error in CLI cleanup: ${error}`)
+    }
+}
+
+export function setupExitHandlers() {
+    // 'exit' cannot perform async work, but the detached cleanup.js spawn
+    // survives the parent exiting, so build-stop still completes.
+    process.on('exit', () => {
+        runExitCleanup()
+    })
+
+    // Signal kills (e.g. CI sending SIGTERM/SIGINT to a hung run) never reach
+    // the 'exit' handler on their own, leaving the Observability build open
+    // until a server-side watchdog closes it hours later. Run the same
+    // cleanup, then re-exit with the conventional code so we don't swallow the
+    // signal. The detached cleanup.js handles the async build-stop. SDK-5981.
+    const handleSignal = (signal: NodeJS.Signals, exitCode: number) => {
+        BStackLogger.debug(`Received ${signal}, running BrowserStack exit cleanup`)
+        try {
+            runExitCleanup()
+        } catch (error) {
+            BStackLogger.debug(`Error during ${signal} cleanup: ${error}`)
+        }
+        process.exit(exitCode)
+    }
+    process.on('SIGINT', () => handleSignal('SIGINT', 130))
+    process.on('SIGTERM', () => handleSignal('SIGTERM', 143))
+
+    // Crashes that would otherwise tear the process down without an 'exit'
+    // event still need the build closed. Run cleanup, then preserve the
+    // default fatal-error behaviour by re-exiting non-zero. SDK-5981.
+    process.on('uncaughtException', (error) => {
+        BStackLogger.debug(`uncaughtException, running BrowserStack exit cleanup: ${error}`)
+        try {
+            runExitCleanup()
+        } catch (cleanupError) {
+            BStackLogger.debug(`Error during uncaughtException cleanup: ${cleanupError}`)
+        }
+        process.exit(1)
+    })
+
+    process.on('unhandledRejection', (reason) => {
+        BStackLogger.debug(`unhandledRejection, running BrowserStack exit cleanup: ${reason}`)
+        try {
+            runExitCleanup()
+        } catch (cleanupError) {
+            BStackLogger.debug(`Error during unhandledRejection cleanup: ${cleanupError}`)
+        }
+    })
+
+    // beforeExit fires when the event loop empties without an explicit exit.
+    // It runs in the normal flow, so cleanup (guarded as idempotent) is safe
+    // here too. SDK-5981.
+    process.on('beforeExit', () => {
+        runExitCleanup()
     })
 }
 

--- a/packages/wdio-browserstack-service/src/insights-handler.ts
+++ b/packages/wdio-browserstack-service/src/insights-handler.ts
@@ -689,6 +689,12 @@ class _InsightsHandler {
             InsightsHandler.currentTest.name = test.title || test.description
         }
 
+        // SDK-5981: a finish event must never carry a null finished_at — an open
+        // timestamp leaves the test (and the build) looking unfinished. Default
+        // it for finish events only, mirroring reporter.ts's testStats.end ||=.
+        const isFinishEvent = eventType === 'TestRunFinished' || eventType === 'HookRunFinished' || eventType === 'TestRunSkipped'
+        const finishedAt = testMetaData.finishedAt ?? (isFinishEvent ? (new Date()).toISOString() : undefined)
+
         const testData: TestData = {
             uuid: testMetaData.uuid,
             type: test.type || 'test',
@@ -704,7 +710,7 @@ class _InsightsHandler {
             location: filename ? path.relative(process.cwd(), filename) : undefined,
             vc_filepath: (this._gitConfigPath && filename) ? path.relative(this._gitConfigPath, filename) : undefined,
             started_at: testMetaData.startedAt,
-            finished_at: testMetaData.finishedAt,
+            finished_at: finishedAt,
             result: 'pending',
             framework: this._framework
         }

--- a/packages/wdio-browserstack-service/src/util.ts
+++ b/packages/wdio-browserstack-service/src/util.ts
@@ -711,6 +711,16 @@ export const getA11yResultsSummary = PerformanceTester.measureWrapper(PERFORMANC
 export const stopBuildUpstream = PerformanceTester.measureWrapper(PERFORMANCE_SDK_EVENTS.TESTHUB_EVENTS.STOP, o11yErrorHandler(async function stopBuildUpstream() {
     const stopBuildUsage = UsageStats.getInstance().stopBuildUsage
     stopBuildUsage.triggered()
+    // Idempotency guard (SDK-5981): if the build was already stopped in this
+    // process, do not send a second PUT .../stop. Termination paths can fire
+    // after onComplete has already stopped the build.
+    if (TestOpsConfig.getInstance().buildStopped) {
+        BStackLogger.debug('[STOP_BUILD] Build already stopped, skipping duplicate stop')
+        return {
+            status: 'success',
+            message: ''
+        }
+    }
     if (!process.env[TESTOPS_BUILD_COMPLETED_ENV]) {
         stopBuildUsage.failed('Build is not completed yet')
         return {
@@ -743,6 +753,8 @@ export const stopBuildUpstream = PerformanceTester.measureWrapper(PERFORMANCE_SD
         })
         BStackLogger.debug(`[STOP_BUILD] Success response: ${await response.text()}`)
         stopBuildUsage.success()
+        // Mark stopped so any later termination path is a no-op (SDK-5981).
+        TestOpsConfig.getInstance().buildStopped = true
         return {
             status: 'success',
             message: ''


### PR DESCRIPTION
## What & why

WebdriverIO **Observability builds were left open ~1h after the real test work ended**, so the TRA build duration reflected a server-side inactivity-watchdog close rather than the test run. Ref: **SDK-5981** (duplicate of **SDK-5908**; same SDK-side class as **SDK-5616** / **TH-5461**, fixed only on `browserstack-node-agent`, never on wdio).

### Root cause
Build-stop cleanup was wired **only to `process.on('exit')`**, which cannot run async work and **never fires on a signal kill** (`SIGTERM`/`SIGINT`). When a test hangs and CI sends the split a `SIGTERM` (or the worker tears down abruptly), the build-stop (`PUT /api/v1/builds/{id}/stop`) is never sent, so the build stays `running` until the backend watchdog times it out — and the reported duration becomes the watchdog interval, not the test run.

### Evidence (production data, `browserstack-production.testhub.*`)
- **Right build:** #209 parent `123875138`, `build_run_id = TMUI9037` (= Jenkins `UIRegression/9037`).
- **The "2h2m" is exact:** parent `duration` = `consolidated_duration` = **7,378,254 ms = 2h 02m 57s**, which equals build start (19:23:02) → the **last straggler's close** (21:26:01) to the second — *not* the parent's own 48m wall clock.
- **Within-build contrast:** in #209, every **healthy** split closed **2–27 s** after its last test; the **two timeout stragglers sat open ~60 min** (3625 s / 3619 s) after their last test, each holding exactly **one hung test** (`finished_at` NULL) — `TC Listing: sort all columns + persist + pagination @p0`.
- **Watchdog fingerprint:** that ~60-min close-after-last-activity is reproduced across **4 stragglers in 2 incidents 10 days apart** (3619–3720 s, total spread 101 s) and is **absent from healthy builds** (control build #205: every split closes in 5–8 s, duration = real wall clock). A fixed interval independent of workload is the signature of a server-side inactivity watchdog.
- **Honest caveat:** the *one wire fact* not directly observable here — that the SDK failed to **emit** the build-stop — lives in the SDK debug log / event store, which is cross-account-inaccessible. The build closing at the watchdog interval rather than promptly is strong indirect evidence (a received stop would have closed it at ~19:52, not 20:53), but the missing-stop step itself is inferred, not observed. (Note: `closed_by`/`closed_at` are NULL on 100% of builds incl. healthy ones — they are NOT evidence.)

## Changes

| File | Change |
|---|---|
| `exitHandler.ts` | **The core fix** — registers the existing detached `cleanup.js` build-stop on `SIGINT`/`SIGTERM`/`uncaughtException`/`unhandledRejection`/`beforeExit` in addition to `exit`. All paths funnel through one **idempotent** `runExitCleanup()`. Existing `exit` behavior + the `BROWSERSTACK_TESTHUB_JWT` cleanup gate unchanged; the CLI-termination body is preserved verbatim. Signal handlers re-exit with conventional codes (130/143). |
| `util.ts` | `stopBuildUpstream` short-circuits if the build was already stopped in this process and sets `TestOpsConfig.buildStopped` on success — within-process guard against a duplicate stop `PUT`. |
| `insights-handler.ts` | `getRunData` defaults `finished_at` to `now()` for finish events (`TestRunFinished`/`HookRunFinished`/`TestRunSkipped`) when unset, mirroring `reporter.ts`'s `testStats.end ||=`. |

## Why this fix addresses the proven cause
The build demonstrably closed only at the ~60-min watchdog, not promptly after the worker's real tests ended. A build-stop received at ~19:52 would have closed the build then (and finalized the hung test as timed-out at that moment). Ensuring build-stop fires on **all** termination paths — including the CI `SIGTERM` that a hung split attracts — makes the build close promptly instead of at the watchdog, collapsing the 2h2m back toward the ~30–50 m of real work.

## Verification
- ⚠️ **Local `tsc`/tests not run** — this checkout has no installed `node_modules`; **relying on PR CI**. Type-safety checked by inspection (`TestData.finished_at: string | undefined`; `getRunData(test, eventType, …)`; `TestOpsConfig.buildStopped` declared). Existing `cleanup.test.ts`/`util.test.ts`/`insights-handler.test.ts` cover the touched modules.
- The **definitive** validation is a local repro (hang a test, `SIGTERM` the run, confirm build-stop fires with this change and not without) and/or TM's `usage-debug.log` from a fresh run — see "Honest caveat" above.

## Reviewer notes
- **`uncaughtException`/`unhandledRejection` registration changes Node's default crash behavior.** `uncaughtException` re-exits non-zero (preserves fail-fast); `unhandledRejection` intentionally does not force-exit. If preferred, these two can be dropped — the core SDK-5981 fix is `SIGINT`/`SIGTERM`/`beforeExit`.
- **Two `buildStopped` flags exist**: `BrowserStackConfig.testObservability.buildStopped` (gates whether `cleanup.js` re-stops) and the new `TestOpsConfig.buildStopped` (within-process duplicate-PUT guard). Cross-process protection still comes from the existing gate + backend idempotency.

## Out of scope (follow-ups)
- **Case 2 — teardown TRF reconciliation:** emit a `TestRunFinished` at `onWorkerEnd`/teardown for any `_tests` entry with a `startedAt` but no `finishedAt`. **This is likely the more complete remedy for the hung-test trigger** — if the backend keeps a build open while a `test_run` is unfinished, reconciling the orphaned run is needed in addition to the build-stop. Worth pairing with this PR.
- **Case 4 — `_tests` title-keyed uuid collision** (duplicate describe+it titles in one worker can overwrite a uuid).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
