### PR TITLE
fix(browserstack-service): skip a11y scan for BiDi window/context commands (SDK-5047)

### DIFF
--- a/packages/wdio-browserstack-service/src/accessibility-handler.ts
+++ b/packages/wdio-browserstack-service/src/accessibility-handler.ts
@@ -521,6 +521,24 @@ class _AccessibilityHandler {
     ])
 
     /**
+     * BiDi detection that also covers MultiRemote: the aggregate multiremote
+     * object does not expose `isBidi` itself — the flag lives on each child
+     * instance — so the session counts as BiDi when the top-level flag is set
+     * OR any multiremote child instance reports `isBidi`.
+     */
+    private static isBidiSession(browser: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser | undefined): boolean {
+        const b = browser as (WebdriverIO.Browser & { isBidi?: boolean, instances?: string[] }) | undefined
+        if (b?.isBidi === true) {
+            return true
+        }
+        if (Array.isArray(b?.instances)) {
+            const children = b as unknown as Record<string, { isBidi?: boolean } | undefined>
+            return b.instances.some((name) => children[name]?.isBidi === true)
+        }
+        return false
+    }
+
+    /**
      * Returns true when the injected pre-command accessibility scan must be
      * skipped: only on BiDi sessions, and only for window/context-management
      * commands. Non-BiDi sessions and all other commands are unaffected and
@@ -529,7 +547,7 @@ class _AccessibilityHandler {
     private static shouldSkipScanForBidiWindowCommand(browser: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser | undefined, command: CommandInfo): boolean {
         return Boolean(
             command?.name &&
-            (browser as (WebdriverIO.Browser & { isBidi?: boolean }) | undefined)?.isBidi === true &&
+            AccessibilityHandler.isBidiSession(browser) &&
             AccessibilityHandler.BIDI_WINDOW_CONTEXT_COMMANDS.has(command.name)
         )
     }

--- a/packages/wdio-browserstack-service/src/accessibility-handler.ts
+++ b/packages/wdio-browserstack-service/src/accessibility-handler.ts
@@ -424,8 +424,10 @@ class _AccessibilityHandler {
      */
 
     private async commandWrapper (command: CommandInfo, prevImpl: Function, origFunction: Function, ...args: unknown[]) {
+        const skipScanForBidiWindowCommand = AccessibilityHandler.shouldSkipScanForBidiWindowCommand(this._browser, command)
         if (
             this._sessionId && AccessibilityHandler._a11yScanSessionMap[this._sessionId] &&
+                !skipScanForBidiWindowCommand &&
                 (
                     !command.name.includes('execute') ||
                     !AccessibilityHandler.shouldPatchExecuteScript(args.length ? args[0] as string : null)
@@ -433,6 +435,8 @@ class _AccessibilityHandler {
         ) {
             BStackLogger.debug(`Performing scan for ${command.class} ${command.name}`)
             await performA11yScan(this.isAppAutomate, this._browser, true, true, command.name)
+        } else if (skipScanForBidiWindowCommand) {
+            BStackLogger.debug(`SDK-5047: skipping accessibility scan for BiDi window/context command '${command.name}' to avoid racing the WebdriverIO ContextManager during session-start window churn`)
         }
         const impl = prevImpl || origFunction
         return impl(...args)
@@ -501,6 +505,32 @@ class _AccessibilityHandler {
         return (
             script.toLowerCase().indexOf('browserstack_executor') !== -1 ||
             script.toLowerCase().indexOf('browserstack_accessibility_automation_script') !== -1
+        )
+    }
+
+    /**
+     * SDK-5047: Window/context-management commands whose surrounding injected
+     * accessibility scan (a browser.execute) races the WebdriverIO v9 core
+     * ContextManager while it (re)binds the browsing context during
+     * session-start window churn on BiDi sessions (e.g. Chrome), surfacing
+     * "no such window: target window already closed / web view not found".
+     */
+    private static readonly BIDI_WINDOW_CONTEXT_COMMANDS = new Set<string>([
+        'getWindowHandle', 'getWindowHandles', 'switchToWindow', 'switchWindow',
+        'newWindow', 'closeWindow', 'switchFrame', 'switchToFrame', 'switchToParentFrame'
+    ])
+
+    /**
+     * Returns true when the injected pre-command accessibility scan must be
+     * skipped: only on BiDi sessions, and only for window/context-management
+     * commands. Non-BiDi sessions and all other commands are unaffected and
+     * keep scanning exactly as before.
+     */
+    private static shouldSkipScanForBidiWindowCommand(browser: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser | undefined, command: CommandInfo): boolean {
+        return Boolean(
+            command?.name &&
+            (browser as (WebdriverIO.Browser & { isBidi?: boolean }) | undefined)?.isBidi === true &&
+            AccessibilityHandler.BIDI_WINDOW_CONTEXT_COMMANDS.has(command.name)
         )
     }
 

--- a/packages/wdio-browserstack-service/tests/accessibility-handler.test.ts
+++ b/packages/wdio-browserstack-service/tests/accessibility-handler.test.ts
@@ -28,6 +28,32 @@ vi.mock('uuid', () => ({ v4: () => '123456789' }))
 const bstackLoggerSpy = vi.spyOn(bstackLogger.BStackLogger, 'logToFile')
 bstackLoggerSpy.mockImplementation(() => {})
 
+describe('shouldSkipScanForBidiWindowCommand (SDK-5047)', () => {
+    const skip = (b: any, c: any) => (AccessibilityHandler as any).shouldSkipScanForBidiWindowCommand(b, c)
+
+    it('skips the injected a11y scan for window/context commands on BiDi sessions', () => {
+        for (const name of ['getWindowHandle', 'getWindowHandles', 'switchToWindow', 'switchWindow', 'newWindow', 'closeWindow', 'switchFrame', 'switchToFrame', 'switchToParentFrame']) {
+            expect(skip({ isBidi: true }, { name, class: 'Browser' })).toBe(true)
+        }
+    })
+
+    it('does not skip for non-window commands on BiDi sessions', () => {
+        expect(skip({ isBidi: true }, { name: 'click', class: 'Element' })).toBe(false)
+        expect(skip({ isBidi: true }, { name: 'url', class: 'Browser' })).toBe(false)
+        expect(skip({ isBidi: true }, { name: 'execute', class: 'Browser' })).toBe(false)
+    })
+
+    it('does not skip on non-BiDi sessions even for window commands', () => {
+        expect(skip({ isBidi: false }, { name: 'getWindowHandle', class: 'Browser' })).toBe(false)
+        expect(skip({}, { name: 'switchToWindow', class: 'Browser' })).toBe(false)
+    })
+
+    it('is safe with undefined browser or missing command name', () => {
+        expect(skip(undefined, { name: 'getWindowHandle', class: 'Browser' })).toBe(false)
+        expect(skip({ isBidi: true }, {})).toBe(false)
+    })
+})
+
 beforeEach(() => {
     vi.mocked(log.info).mockClear()
     vi.mocked(fetch).mockClear()

--- a/packages/wdio-browserstack-service/tests/accessibility-handler.test.ts
+++ b/packages/wdio-browserstack-service/tests/accessibility-handler.test.ts
@@ -52,6 +52,17 @@ describe('shouldSkipScanForBidiWindowCommand (SDK-5047)', () => {
         expect(skip(undefined, { name: 'getWindowHandle', class: 'Browser' })).toBe(false)
         expect(skip({ isBidi: true }, {})).toBe(false)
     })
+
+    it('skips for window commands when any multiremote child instance is BiDi', () => {
+        const multi = { instances: ['chromeA', 'chromeB'], chromeA: { isBidi: false }, chromeB: { isBidi: true } }
+        expect(skip(multi, { name: 'getWindowHandle', class: 'Browser' })).toBe(true)
+        expect(skip(multi, { name: 'switchToWindow', class: 'Browser' })).toBe(true)
+    })
+
+    it('does not skip on multiremote when no child instance is BiDi', () => {
+        const multi = { instances: ['chromeA', 'chromeB'], chromeA: { isBidi: false }, chromeB: {} }
+        expect(skip(multi, { name: 'getWindowHandle', class: 'Browser' })).toBe(false)
+    })
 })
 
 beforeEach(() => {


### PR DESCRIPTION
## Proposed changes

On WebdriverIO v9 BiDi sessions (Chrome), sessions intermittently break at start-up with `no such window: target window already closed` / `web view not found` when running `"window"` (GET). The failure is **accessibility-conditional** (only with `accessibility: true`) and **Chrome-only** (Edge passes).

Root cause: `@wdio/browserstack-service` wraps `commandsToWrap` and injects an accessibility scan (`browser.execute(performScan)`) **before each wrapped command** in `AccessibilityHandler.commandWrapper`. On v9 BiDi, Chrome churns the browsing context at session start; the injected `browser.execute` pokes the window/context machinery during that unstable window (the core `ContextManager` reacts to `browsingContext.navigationStarted` / `getWindowHandle`), surfacing "no such window". Because injecting these early scans is the only behaviour that changes when accessibility is enabled, the failure originates in the service's command-wrapping, not WDIO core.

Fix: on BiDi sessions only, skip the injected pre-command accessibility scan for window/context-management commands (`getWindowHandle`, `getWindowHandles`, `switchToWindow`, `switchWindow`, `newWindow`, `closeWindow`, `switchFrame`, `switchToFrame`, `switchToParentFrame`). Non-BiDi sessions and all other commands scan exactly as before.

Ref: SDK-5047.

## Types of changes

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate) — N/A (behavioural guard, no public API change)
- [ ] I have added proper type definitions for new commands (if appropriate) — N/A (no new commands)

## Backport Request

- [x] This change is solely for `v9` and doesn't need to be back-ported (the issue is specific to the v9 BiDi `ContextManager`; v8 is unaffected)
- [ ] Back-ported PR at `#XXXXX`

## Further comments

- Testing: new unit tests for the pure guard helper `shouldSkipScanForBidiWindowCommand` (skips on BiDi + window/context command; does not skip for other commands or on non-BiDi sessions; safe with undefined inputs). `accessibility-handler.test.ts` passes with no regressions; TypeScript typecheck clean. End-to-end validation on BrowserStack (WDIO v9 BiDi mocha + `accessibility:true` on Chrome) is pending.
- Base note: this PR targets **this fork's `main`** because the fork is ~46 commits behind `webdriverio/webdriverio:main`; targeting the fork's main keeps the diff to exactly the 2 changed files. Retarget to upstream after syncing the fork if an upstream contribution is intended.

### Reviewers: @webdriverio/project-committers