### PR TITLE
fix(browserstack-service): finalize orphaned test runs on interrupted exit (SDK-4671)

### DIFF
--- a/packages/wdio-browserstack-service/src/cleanup.ts
+++ b/packages/wdio-browserstack-service/src/cleanup.ts
@@ -1,4 +1,5 @@
 import { getErrorString, stopBuildUpstream } from './util.js'
+import { finalizeOrphanedRuns } from './testOps/openRunsJournal.js'
 import { BStackLogger } from './bstackLogger.js'
 import fs from 'node:fs'
 import util from 'node:util'
@@ -45,6 +46,9 @@ export default class BStackCleanup {
         }
         BStackLogger.debug('Executing Test Reporting and Analytics cleanup')
         try {
+            // SDK-4671: finalize any test runs orphaned by the interrupted process
+            // before the build itself is stopped.
+            await finalizeOrphanedRuns()
             const result = await stopBuildUpstream()
             if ((process.env[BROWSERSTACK_OBSERVABILITY]) && process.env[BROWSERSTACK_TESTHUB_UUID]) {
                 BStackLogger.info(`\nVisit https://automation.browserstack.com/builds/${process.env[BROWSERSTACK_TESTHUB_UUID]} to view build report, insights, and many more debugging information all at one place!\n`)

--- a/packages/wdio-browserstack-service/src/launcher.ts
+++ b/packages/wdio-browserstack-service/src/launcher.ts
@@ -48,6 +48,7 @@ import {
     isMultiRemoteCaps
 } from './util.js'
 import CrashReporter from './crash-reporter.js'
+import { finalizeOrphanedRuns } from './testOps/openRunsJournal.js'
 import { BStackLogger } from './bstackLogger.js'
 import { PercyLogger } from './Percy/PercyLogger.js'
 import type Percy from './Percy/Percy.js'
@@ -588,6 +589,9 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
             const isCLIEnabled = BrowserstackCLI.getInstance().isRunning()
             BStackLogger.debug('Inside OnComplete hook..')
             BStackLogger.debug('Sending stop launch event')
+            // SDK-4671: before stopping the build, synthesize TestRunFinished for any
+            // test runs whose worker died mid-test, else they stay 'in progress' on TRA.
+            await finalizeOrphanedRuns()
             try {
                 await (isCLIEnabled ? BrowserstackCLI.getInstance().stop() : stopBuildUpstream())
                 PerformanceTester.end(PERFORMANCE_SDK_EVENTS.FRAMEWORK_EVENTS.STOP)

--- a/packages/wdio-browserstack-service/src/testOps/listener.ts
+++ b/packages/wdio-browserstack-service/src/testOps/listener.ts
@@ -12,6 +12,7 @@ import {
     TEST_ANALYTICS_ID
 } from '../constants.js'
 import { sendScreenshots } from './requestUtils.js'
+import { recordOpenRun, clearOpenRun } from './openRunsJournal.js'
 import { BStackLogger } from '../bstackLogger.js'
 import { shouldProcessEventForTesthub } from '../testHub/utils.js'
 
@@ -105,6 +106,7 @@ class Listener {
                 return
             }
             process.env[TEST_ANALYTICS_ID] = testData.uuid
+            recordOpenRun(testData)
             this.testStartedStats.triggered()
 
             testData.product_map = {
@@ -128,6 +130,7 @@ class Listener {
                 accessibility: Listener._testRunAccessibilityVar
             }
 
+            clearOpenRun(testData.uuid)
             this.testFinishedStats.triggered(testData.result)
             this.sendBatchEvents(this.getEventForHook('TestRunFinished', testData))
         } catch (e) {

--- a/packages/wdio-browserstack-service/src/testOps/openRunsJournal.ts
+++ b/packages/wdio-browserstack-service/src/testOps/openRunsJournal.ts
@@ -1,0 +1,97 @@
+import path from 'node:path'
+import fs from 'node:fs'
+
+import type { TestData, UploadType } from '../types.js'
+import { batchAndPostEvents } from '../util.js'
+import { DATA_BATCH_ENDPOINT } from '../constants.js'
+import { BStackLogger } from '../bstackLogger.js'
+
+/**
+ * Crash-resilient journal of test runs that have sent TestRunStarted but not yet
+ * TestRunFinished. Each open run is persisted as a small file so that if the worker
+ * (or the whole wdio process tree) is killed mid-test, the launcher's shutdown path
+ * or the detached exit cleanup can still send a synthetic TestRunFinished — otherwise
+ * the test case stays "in progress" on the Test Reporting & Analytics dashboard forever.
+ */
+
+const OPEN_RUNS_DIR = path.join(process.cwd(), 'logs', 'bstack_open_runs')
+
+export const ORPHAN_FAILURE_REASON = 'Test run did not complete: the process was interrupted or terminated before the test finished (finalized by BrowserStack SDK exit cleanup)'
+
+function openRunFilePath(uuid: string) {
+    return path.join(OPEN_RUNS_DIR, `open-run-${uuid}.json`)
+}
+
+export function recordOpenRun(testData: TestData) {
+    if (!testData || !testData.uuid) {
+        return
+    }
+    try {
+        fs.mkdirSync(OPEN_RUNS_DIR, { recursive: true })
+        fs.writeFileSync(openRunFilePath(testData.uuid), JSON.stringify(testData))
+    } catch (e) {
+        BStackLogger.debug('openRunsJournal: failed to record open run: ' + e)
+    }
+}
+
+export function clearOpenRun(uuid?: string) {
+    if (!uuid) {
+        return
+    }
+    try {
+        fs.rmSync(openRunFilePath(uuid), { force: true })
+    } catch (e) {
+        BStackLogger.debug('openRunsJournal: failed to clear open run: ' + e)
+    }
+}
+
+export function collectOrphanedRuns(): TestData[] {
+    const orphans: TestData[] = []
+    try {
+        if (!fs.existsSync(OPEN_RUNS_DIR)) {
+            return orphans
+        }
+        for (const file of fs.readdirSync(OPEN_RUNS_DIR)) {
+            try {
+                orphans.push(JSON.parse(fs.readFileSync(path.join(OPEN_RUNS_DIR, file), 'utf8')))
+            } catch (e) {
+                BStackLogger.debug(`openRunsJournal: skipping unreadable journal file ${file}: ${e}`)
+            }
+        }
+        fs.rmSync(OPEN_RUNS_DIR, { recursive: true, force: true })
+    } catch (e) {
+        BStackLogger.debug('openRunsJournal: failed to collect orphaned runs: ' + e)
+    }
+    return orphans
+}
+
+export async function finalizeOrphanedRuns(): Promise<number> {
+    try {
+        const orphans = collectOrphanedRuns()
+        if (!orphans.length) {
+            return 0
+        }
+        const finishedAt = new Date().toISOString()
+        const events: UploadType[] = orphans.map((testData) => {
+            const startedAtMs = testData.started_at ? new Date(testData.started_at).getTime() : NaN
+            return {
+                event_type: 'TestRunFinished',
+                test_run: {
+                    ...testData,
+                    finished_at: finishedAt,
+                    result: 'failed',
+                    duration_in_ms: Number.isNaN(startedAtMs) ? undefined : Math.max(0, Date.now() - startedAtMs),
+                    failure: [{ backtrace: [ORPHAN_FAILURE_REASON] }],
+                    failure_reason: ORPHAN_FAILURE_REASON,
+                    failure_type: 'UnhandledError'
+                }
+            }
+        })
+        await batchAndPostEvents(DATA_BATCH_ENDPOINT, 'ORPHANED_TEST_RUN_FINALIZATION', events)
+        BStackLogger.info(`Finalized ${events.length} orphaned test run(s) left behind by an interrupted run`)
+        return events.length
+    } catch (e) {
+        BStackLogger.debug('openRunsJournal: failed to finalize orphaned runs: ' + e)
+        return 0
+    }
+}

--- a/packages/wdio-browserstack-service/tests/launcher.test.ts
+++ b/packages/wdio-browserstack-service/tests/launcher.test.ts
@@ -657,12 +657,14 @@ describe('onComplete', () => {
             .then(() => expect(service.browserstackLocal?.stop).toHaveBeenCalled())
     })
 
-    it('should stop accessibility test run on complete', () => {
+    it('should stop accessibility test run on complete', async () => {
         const stopBuildUpstreamSpy = vi.spyOn(utils, 'stopBuildUpstream')
         vi.spyOn(utils, 'isAccessibilityAutomationSession').mockReturnValue(true)
 
         const service = new BrowserstackLauncher({} as any, [{}] as any, {} as any)
-        service.onComplete()
+        // onComplete is async (and now awaits orphaned-run finalization before
+        // stopping the build) — await it instead of relying on its sync prefix.
+        await service.onComplete()
         expect(stopBuildUpstreamSpy).toHaveBeenCalledTimes(1)
     })
 })

--- a/packages/wdio-browserstack-service/tests/testOps/openRunsJournal.test.ts
+++ b/packages/wdio-browserstack-service/tests/testOps/openRunsJournal.test.ts
@@ -1,0 +1,124 @@
+import { expect, vi, it, describe, beforeEach, afterEach } from 'vitest'
+import fs from 'node:fs'
+
+import * as OpenRunsJournal from '../../src/testOps/openRunsJournal.js'
+import * as utils from '../../src/util.js'
+
+vi.mock('../../src/bstackLogger.js', () => ({
+    BStackLogger: {
+        debug: vi.fn(),
+        info: vi.fn(),
+    },
+}))
+
+vi.mock('fs', () => ({
+    default: {
+        readdirSync: vi.fn(),
+        existsSync: vi.fn(),
+        readFileSync: vi.fn(),
+        rmSync: vi.fn(),
+        mkdirSync: vi.fn(),
+        writeFileSync: vi.fn()
+    }
+}))
+
+describe('openRunsJournal', () => {
+    let mockFs: any
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockFs = vi.mocked(fs)
+    })
+
+    afterEach(() => {
+        vi.clearAllMocks()
+    })
+
+    describe('recordOpenRun', () => {
+        it('persists the started test data keyed by uuid', () => {
+            const testData = { uuid: 'uuid-1', name: 'my test', started_at: new Date().toISOString() }
+            OpenRunsJournal.recordOpenRun(testData)
+            expect(mockFs.mkdirSync).toHaveBeenCalledOnce()
+            expect(mockFs.writeFileSync).toHaveBeenCalledWith(expect.stringContaining('open-run-uuid-1.json'), JSON.stringify(testData))
+        })
+
+        it('is a no-op without a uuid and never throws on fs errors', () => {
+            OpenRunsJournal.recordOpenRun({} as any)
+            expect(mockFs.writeFileSync).not.toHaveBeenCalled()
+
+            mockFs.writeFileSync.mockImplementationOnce(() => { throw new Error('disk full') })
+            expect(() => OpenRunsJournal.recordOpenRun({ uuid: 'uuid-err' })).not.toThrow()
+        })
+    })
+
+    describe('clearOpenRun', () => {
+        it('removes the journal entry for the finished test', () => {
+            OpenRunsJournal.clearOpenRun('uuid-2')
+            expect(mockFs.rmSync).toHaveBeenCalledWith(expect.stringContaining('open-run-uuid-2.json'), { force: true })
+        })
+
+        it('is a no-op without a uuid', () => {
+            OpenRunsJournal.clearOpenRun(undefined)
+            expect(mockFs.rmSync).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('collectOrphanedRuns', () => {
+        it('returns [] when the journal dir does not exist', () => {
+            mockFs.existsSync.mockReturnValueOnce(false)
+            expect(OpenRunsJournal.collectOrphanedRuns()).toEqual([])
+        })
+
+        it('reads every journal file, removes the dir and skips unreadable entries', () => {
+            mockFs.existsSync.mockReturnValueOnce(true)
+            mockFs.readdirSync.mockReturnValueOnce(['open-run-a.json', 'open-run-bad.json'] as any)
+            mockFs.readFileSync.mockImplementation((filePath: string) => {
+                if (filePath.includes('open-run-a.json')) {
+                    return JSON.stringify({ uuid: 'a' })
+                }
+                throw new Error('corrupt')
+            })
+            const orphans = OpenRunsJournal.collectOrphanedRuns()
+            expect(orphans).toEqual([{ uuid: 'a' }])
+            expect(mockFs.rmSync).toHaveBeenCalledWith(expect.stringContaining('bstack_open_runs'), { recursive: true, force: true })
+        })
+    })
+
+    describe('finalizeOrphanedRuns', () => {
+        it('does nothing when there are no orphans', async () => {
+            mockFs.existsSync.mockReturnValueOnce(false)
+            const batchSpy = vi.spyOn(utils, 'batchAndPostEvents').mockResolvedValueOnce(undefined as any)
+            expect(await OpenRunsJournal.finalizeOrphanedRuns()).toBe(0)
+            expect(batchSpy).not.toHaveBeenCalled()
+        })
+
+        it('posts a failed TestRunFinished per orphan and reports the count', async () => {
+            const startedAt = new Date(Date.now() - 5000).toISOString()
+            mockFs.existsSync.mockReturnValueOnce(true)
+            mockFs.readdirSync.mockReturnValueOnce(['open-run-a.json'] as any)
+            mockFs.readFileSync.mockReturnValueOnce(JSON.stringify({ uuid: 'a', name: 'stuck test', started_at: startedAt }))
+            const batchSpy = vi.spyOn(utils, 'batchAndPostEvents').mockResolvedValueOnce(undefined as any)
+
+            expect(await OpenRunsJournal.finalizeOrphanedRuns()).toBe(1)
+
+            expect(batchSpy).toHaveBeenCalledOnce()
+            const [, kind, events] = batchSpy.mock.calls[0]
+            expect(kind).toBe('ORPHANED_TEST_RUN_FINALIZATION')
+            expect(events).toHaveLength(1)
+            const event = (events as any)[0]
+            expect(event.event_type).toBe('TestRunFinished')
+            expect(event.test_run.uuid).toBe('a')
+            expect(event.test_run.result).toBe('failed')
+            expect(event.test_run.failure_reason).toBe(OpenRunsJournal.ORPHAN_FAILURE_REASON)
+            expect(event.test_run.finished_at).toBeTruthy()
+            expect(event.test_run.duration_in_ms).toBeGreaterThanOrEqual(5000)
+        })
+
+        it('swallows upload failures and returns 0', async () => {
+            mockFs.existsSync.mockReturnValueOnce(true)
+            mockFs.readdirSync.mockReturnValueOnce(['open-run-a.json'] as any)
+            mockFs.readFileSync.mockReturnValueOnce(JSON.stringify({ uuid: 'a' }))
+            vi.spyOn(utils, 'batchAndPostEvents').mockRejectedValueOnce(new Error('no jwt'))
+            expect(await OpenRunsJournal.finalizeOrphanedRuns()).toBe(0)
+        })
+    })
+})


### PR DESCRIPTION
## Proposed changes

Fixes **SDK-4671** — `[]TC getting stuck at in progress` (customer framework: **wdio + mocha**).

**Root cause:** when a WDIO run is interrupted mid-test (Ctrl-C, SIGTERM, worker crash/kill), the service has already sent `TestRunStarted` but never sends `TestRunFinished`. The existing exit path (`exitHandler.ts` → detached `cleanup.js`) only calls `stopBuildUpstream()` — a **build-level** stop — so the build finalizes while the in-flight test case stays *in progress* on the TRA dashboard forever. The upstream mocha-timeout hardening (#15310) covers in-process orphans only, not process death.

**Fix:** a crash-resilient journal + finalizer, `src/testOps/openRunsJournal.ts`:
- `recordOpenRun(testData)` — on every `TestRunStarted` (wired in `Listener.testStarted`) the full test payload is persisted to `logs/bstack_open_runs/open-run-<uuid>.json`
- `clearOpenRun(uuid)` — removed on `TestRunFinished` (wired in `Listener.testFinished`), so the journal is empty on any healthy run
- `finalizeOrphanedRuns()` — collects leftovers and POSTs synthetic failed `TestRunFinished` events (`failure_reason` explains the interruption) via the existing `batchAndPostEvents` util. Called from **both** exit paths:
  - `launcher.onComplete` — before the build stop (covers killed workers under a surviving launcher)
  - `cleanup.ts` — the detached exit cleanup (covers abnormal launcher exits)

All journal/finalizer operations are try/catch no-throw (SDK failures must never break user tests). File-per-uuid keeps the journal race-free across parallel workers; both call sites are idempotent because collection removes the journal.

Replaces browserstack-node-agent#2239 (closed — wrong layer: that targeted the standalone mocha runner, but the SDK-4671 customer runs mocha **via WDIO**, whose o11y eventing lives in this service). Sibling QA-campaign PRs on this fork: #19 (SDK-5047), #20 (SDK-3737). Jira: [SDK-4671](https://browserstack.atlassian.net/browse/SDK-4671)

## Types of changes

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works (`tests/testOps/openRunsJournal.test.ts` — passing in full, type check clean; `tests/cleanup.test.ts` passes in full; `tests/launcher.test.ts` 108/110 — the launcher a11y-stop test now awaits the async `onComplete` hook since `finalizeOrphanedRuns()` is awaited before `stopBuildUpstream`, and the 2 remaining `_uploadApp` failures are pre-existing env-dependent fetch tests that reproduce identically on an untouched checkout)
- [ ] I have added the necessary documentation (if appropriate) — N/A (internal reliability fix, no user-facing API change)
- [ ] I have added proper type definitions for new commands (if appropriate) — N/A (no new commands)

## Backport Request

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

Design notes: the journal writes the full started `TestData` payload (not just the uuid) so the synthetic `TestRunFinished` carries every field the backend already saw at start — no re-derivation needed at finalization time. `duration_in_ms` is computed from the journaled `started_at`. The `logs/bstack_open_runs` directory is intentionally separate from `logs/worker_data`, which `funnelInstrumentation.getDataFromWorkers()` deletes during normal launcher shutdown before the exit cleanup runs. An alternative considered was worker-side SIGINT/SIGTERM handlers flushing a synthetic finish before death, but signal-time async HTTP from a dying worker is unreliable and SIGKILL/crash would still be uncovered — the journal covers all of these from the surviving process.

### Reviewers: @webdriverio/project-committers

