### PR TITLE
fix(a11y): route WDIO CLI-flow App Automate sessions to app-accessibility (SDK-3813)

### DIFF
--- a/packages/wdio-browserstack-service/src/cli/modules/accessibilityModule.ts
+++ b/packages/wdio-browserstack-service/src/cli/modules/accessibilityModule.ts
@@ -79,6 +79,15 @@ export default class AccessibilityModule extends BaseModule {
                 platform_name: browserCaps?.platformName,
                 platform_version: this.getCapability(browserCaps, 'appium:platformVersion', 'platformVersion'),
             }
+
+            // App Automate sessions must run the app-accessibility flow, not the
+            // Chrome-only web path. The binary's isAppAccessibility flag is not
+            // guaranteed to be set on the CLI path, so derive app-ness from caps the
+            // same way the classic flow does (service._isAppAutomate).
+            if (this.isAppAutomateSession(inputCaps, browserCaps)) {
+                this.isAppAccessibility = true
+            }
+
             if (this.isAppAccessibility) {
                 this.accessibility = validateCapsWithAppA11y(platformA11yMeta)
             } else {
@@ -130,12 +139,11 @@ export default class AccessibilityModule extends BaseModule {
                 return
             }
 
-            if (!('overwriteCommand' in browser && Array.isArray(this.scriptInstance.commandsToWrap))) {
-                return
-            }
-
-            // Wrap commands if accessibility scripts are available
-            if (this.scriptInstance.commandsToWrap && this.scriptInstance.commandsToWrap.length > 0) {
+            // Web command wrapping (overwriteCommand) only applies to the web a11y
+            // flow. App Automate a11y scans run via the performScan/test-lifecycle
+            // path, and appium drivers don't register these commands, so
+            // overwriteCommand would throw and abort onBeforeExecute.
+            if (!this.isAppAccessibility && 'overwriteCommand' in browser && Array.isArray(this.scriptInstance.commandsToWrap)) {
                 this.scriptInstance.commandsToWrap
                     .filter((command) => command.name && command.class)
                     .forEach((command) => {
@@ -364,6 +372,18 @@ export default class AccessibilityModule extends BaseModule {
             }
         }
 
+    }
+
+    // Mirrors service._isAppAutomate: an App Automate session is identified by the
+    // presence of an app capability (appium:app / appium:options.app).
+    private isAppAutomateSession(inputCaps?: WebdriverIO.Capabilities, browserCaps?: WebdriverIO.Capabilities): boolean {
+        for (const caps of [inputCaps, browserCaps]) {
+            const c = (caps ?? {}) as Record<string, unknown>
+            if (c['appium:app'] || (c['appium:options'] as { app?: unknown } | undefined)?.app) {
+                return true
+            }
+        }
+        return false
     }
 
     private async performScanCli(

--- a/packages/wdio-browserstack-service/tests/cli/modules/accessibilityModule.test.ts
+++ b/packages/wdio-browserstack-service/tests/cli/modules/accessibilityModule.test.ts
@@ -51,6 +51,8 @@ vi.mock('../../../src/cli/grpcClient.js', () => ({
 }))
 
 import AccessibilityModule from '../../../src/cli/modules/accessibilityModule.js'
+import { validateCapsWithA11y, validateCapsWithAppA11y } from '../../../src/util.js'
+import accessibilityScripts from '../../../src/scripts/accessibility-scripts.js'
 import TestFramework from '../../../src/cli/frameworks/testFramework.js'
 import AutomationFramework from '../../../src/cli/frameworks/automationFramework.js'
 import { AutomationFrameworkState } from '../../../src/cli/states/automationFrameworkState.js'
@@ -364,6 +366,81 @@ describe('AccessibilityModule', () => {
             const result = await accessibilityModule.getA11yResultsSummary(mockBrowser)
 
             expect(result).toEqual({})
+        })
+    })
+
+    // SDK-3813: App Automate + App Accessibility sessions were mis-routed onto the
+    // web a11y path (Chrome-only gate + overwriteCommand on commands absent from the
+    // appium driver), so App A11y scans never ran. The CLI module must detect app
+    // sessions from caps (like the classic flow) and skip web command wrapping.
+    describe('onBeforeExecute - App Automate (SDK-3813)', () => {
+        const appGetState = (instance: any, key: string) => {
+            if (key.includes('input_capabilities')) {
+                return { 'appium:app': 'bs://BrowserStackMobileAppId' }
+            }
+            if (key.includes('capabilities')) {
+                return { platformName: 'android', platformVersion: '13' }
+            }
+            if (key.includes('session_id')) {
+                return 12345
+            }
+            return {}
+        }
+
+        afterEach(() => {
+            accessibilityScripts.commandsToWrap = []
+        })
+
+        it('detects app session from caps and skips web command-overwrite', async () => {
+            // binary flag is false; caps say app -> module must still take app path
+            vi.mocked(validateCapsWithAppA11y).mockReturnValue(true)
+            vi.mocked(validateCapsWithA11y).mockReturnValue(true)
+            accessibilityScripts.commandsToWrap = [
+                { name: 'click', class: 'Browser' },
+                { name: 'startA11yScanning', class: 'Browser' }
+            ]
+            vi.mocked(AutomationFramework.getState).mockImplementation(appGetState as any)
+
+            await accessibilityModule.onBeforeExecute()
+
+            expect(accessibilityModule.isAppAccessibility).toBe(true)
+            // Symptom 1: no web command-overwrite attempted on an app session
+            expect(mockBrowser.overwriteCommand).not.toHaveBeenCalled()
+            // Symptom 2: Chrome-only web gate never consulted; app validation used
+            expect(validateCapsWithAppA11y).toHaveBeenCalled()
+            expect(validateCapsWithA11y).not.toHaveBeenCalled()
+        })
+
+        it('engages the app performScan path (execute, not web executeAsync)', async () => {
+            vi.mocked(validateCapsWithAppA11y).mockReturnValue(true)
+            vi.mocked(validateCapsWithA11y).mockReturnValue(true)
+            vi.mocked(AutomationFramework.getState).mockImplementation(appGetState as any)
+            mockBrowser.execute.mockResolvedValue({ scanned: true })
+
+            await accessibilityModule.onBeforeExecute()
+            const result = await mockBrowser.performScan()
+
+            expect(mockBrowser.execute).toHaveBeenCalled()
+            expect(mockBrowser.executeAsync).not.toHaveBeenCalled()
+            expect(result).toEqual({ scanned: true })
+        })
+
+        it('does not abort onBeforeExecute when web command wrapping would throw', async () => {
+            vi.mocked(validateCapsWithAppA11y).mockReturnValue(true)
+            vi.mocked(validateCapsWithA11y).mockReturnValue(true)
+            accessibilityScripts.commandsToWrap = [{ name: 'startA11yScanning', class: 'Browser' }]
+            mockBrowser.overwriteCommand = vi.fn(() => {
+                throw new Error('overwriteCommand: no command to be overwritten: startA11yScanning')
+            })
+            const errorSpy = vi.spyOn(accessibilityModule.logger, 'error')
+            vi.mocked(AutomationFramework.getState).mockImplementation(appGetState as any)
+
+            await accessibilityModule.onBeforeExecute()
+
+            expect(mockBrowser.overwriteCommand).not.toHaveBeenCalled()
+            expect(errorSpy).not.toHaveBeenCalledWith(
+                expect.stringContaining('Error in onBeforeExecute')
+            )
         })
     })
 })


### PR DESCRIPTION
## Proposed changes

The CLI-flow AccessibilityModule decided web-vs-app a11y solely from the binary’s `isAppAccessibility` flag, which the SDK never derives. On App Automate sessions where the flag is unset, `onBeforeExecute` took the web path: it emitted "Accessibility Automation will run only on Chrome browsers." and ran the web command-wrap loop, which threw `overwriteCommand: no command to be overwritten: startA11yScanning` (uncaught, unlike the classic handler’s try/catch) — so App A11y scans never ran and results lacked severity/totalIssueCount.

Fix: derive app-ness from caps (`appium:app` / `appium:options.app`, input + resolved) exactly like the classic flow’s `_isAppAutomate`, force the app-accessibility path on app sessions, and skip web command wrapping on app sessions. Web a11y behavior unchanged. Tracked internally as SDK-3813.

## Types of changes

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

New tests: 3 cases in `tests/cli/modules/accessibilityModule.test.ts` ("onBeforeExecute - App Automate (SDK-3813)") — all 3 fail on the unpatched module and pass with the fix (26 passed, no type errors; pre-existing unrelated failures untouched). No new commands, so no new type definitions; no docs impact.

## Backport Request

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

The detection helper reads the resolved capabilities written at driver-create time (before this hook runs), so it fires even when raw input caps are `bstack:options`-shaped. The web command-wrap loop is gated rather than try/caught to mirror the *decision* of the classic handler without claiming its per-command error-handling hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MX6rwQ3yn7iE1seu7H6cVm

### Reviewers: @webdriverio/project-committers